### PR TITLE
vaultwarden 마이그레이션

### DIFF
--- a/helm/vaultwarden.yaml
+++ b/helm/vaultwarden.yaml
@@ -1,0 +1,72 @@
+env:
+  DATA_FOLDER: config
+  DISABLE_ICON_DOWNLOAD: true
+  DOMAIN: https://vw.bacchus.io
+  ORG_CREATION_USERS: null
+  SIGNUPS_ALLOWED: true
+  SIGNUPS_DOMAINS_WHITELIST: bacchus.snucse.org
+  SIGNUPS_VERIFY: true
+  SMTP_FROM: no-reply@snucse.org
+  SMTP_HOST: smtp.gmail.com
+  SMTP_PASSWORD: 
+    valueFrom:
+      secretKeyRef:
+        name: vaultwarden-secret
+        key: smtp-password
+  SMTP_PORT: 587
+  SMTP_SSL: true
+  SMTP_USERNAME: no-reply@snucse.org
+  TZ: Asia/Seoul
+  WEBSOCKET_ENABLED: true
+
+image:
+  pullPolicy: IfNotPresent
+  repository: vaultwarden/server
+  tag: null
+
+ingress:
+  main:
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+    enabled: true
+    hosts:
+    - host: vw.bacchus.io
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          port: 80
+      - path: /notifications/hub/negotiate
+        pathType: Prefix
+        service:
+          port: 80
+      - path: /notifications/hub
+        pathType: Prefix
+        service:
+          port: 3012
+    ingressClassName: alb
+
+persistence:
+  config:
+    enabled: true
+    size: 16Gi
+    retain: true
+
+mariadb:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+service:
+  main:
+    ports:
+      http:
+        port: 80
+      websocket:
+        enabled: true
+        port: 3012
+
+strategy:
+  type: Recreate


### PR DESCRIPTION
기존 `bacchus-dev` 클러스터에 있는 `valutwarden`을 마이그레이션합니다.

1. `bartender` 클러스터에서 `vaultwarden` 네임스페이스 및 `vaultwarden-config` pvc 생성
2. `bacchus-dev` 클러스터의 `vaultwarden` 팟에 접속하여 tar로 config 디렉토리를 빼옴
3. `bartender` 클러스터에서 `vaultwarden-config`를 마운트하는 임시 팟을 생성한 후 앞에서 빼낸 tar 파일을 풀어서 집어넣음
4. 코드 작성 후 네임스페이스와 pvc는 import