### PR TITLE
pvc 이름 수정

### DIFF
--- a/eks_bartender.tf
+++ b/eks_bartender.tf
@@ -489,7 +489,7 @@ resource "helm_release" "vaultwarden" {
 
   set {
     name  = "persistence.config.existingClaim"
-    value = kubernetes_persistent_volume_claim.vaultwarden_config.id
+    value = split("/", (kubernetes_persistent_volume_claim.vaultwarden_config.id))[1]
   }
 
   values = [


### PR DESCRIPTION
pvc 리소스의 id가 <namespace>.<name> 이므로 `/` 앞을 잘라야 합니다.