### PR TITLE
aws-auth 컨피그맵 및 프로바이더 제거

### DIFF
--- a/eks_bacchus_dev.tf
+++ b/eks_bacchus_dev.tf
@@ -1,25 +1,6 @@
-# https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2009#issuecomment-1096628912
-provider "kubernetes" {
-  alias = "bacchus_dev"
-
-  host                   = module.eks_bacchus_dev.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks_bacchus_dev.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks_bacchus_dev.cluster_id]
-  }
-}
-
 module "eks_bacchus_dev" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 18.20"
-
-  providers = {
-    kubernetes = kubernetes.bacchus_dev
-  }
 
   cluster_name                    = "bacchus-dev"
   cluster_version                 = "1.22"
@@ -45,7 +26,7 @@ module "eks_bacchus_dev" {
 
   cluster_enabled_log_types = []
 
-  manage_aws_auth_configmap = true
+  manage_aws_auth_configmap = false
 
   aws_auth_users = [for username in aws_iam_group_membership.bacchus_admin.users : {
     userarn  = aws_iam_user.bacchus[username].arn,


### PR DESCRIPTION
컨피그맵은 사이클 이슈로 플랜이 자꾸 실패해서 `terraform state rm`으로 상태를 지웠습니다.