### PR TITLE
하드웨어 실습실, 라운지, 서버 매트릭 수집

### DIFF
--- a/eks_bartender.tf
+++ b/eks_bartender.tf
@@ -406,7 +406,8 @@ resource "helm_release" "dashboard" {
   ]
 
   values = [
-    file("helm/kube-prometheus-stack.yaml")
+    file("helm/kube-prometheus-stack.yaml"),
+    file("helm/kube-prometheus-additional-scrape-configs.yaml")
   ]
 }
 

--- a/helm/kube-prometheus-additional-scrape-configs.yaml
+++ b/helm/kube-prometheus-additional-scrape-configs.yaml
@@ -1,0 +1,201 @@
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+    - job_name: 'hardware-lab'
+      metrics_path: /metrics
+      static_configs:
+      - targets: ['147.46.78.190:9100']
+        labels:
+          machine_id: '311-2-01'
+      - targets: ['147.46.78.191:9100']
+        labels:
+          machine_id: '311-2-02'
+      - targets: ['147.46.78.192:9100']
+        labels:
+          machine_id: '311-2-03'
+      - targets: ['147.46.78.193:9100']
+        labels:
+          machine_id: '311-2-04'
+      - targets: ['147.46.78.194:9100']
+        labels:
+          machine_id: '311-2-05'
+      - targets: ['147.46.78.195:9100']
+        labels:
+          machine_id: '311-2-06'
+      - targets: ['147.46.78.196:9100']
+        labels:
+          machine_id: '311-2-07'
+      - targets: ['147.46.78.197:9100']
+        labels:
+          machine_id: '311-2-08'
+      - targets: ['147.46.78.198:9100']
+        labels:
+          machine_id: '311-2-09'
+      - targets: ['147.46.78.199:9100']
+        labels:
+          machine_id: '311-2-10'
+      - targets: ['147.46.78.200:9100']
+        labels:
+          machine_id: '311-2-11'
+      - targets: ['147.46.78.201:9100']
+        labels:
+          machine_id: '311-2-12'
+      - targets: ['147.46.78.202:9100']
+        labels:
+          machine_id: '311-2-13'
+      - targets: ['147.46.78.203:9100']
+        labels:
+          machine_id: '311-2-14'
+      - targets: ['147.46.78.204:9100']
+        labels:
+          machine_id: '311-2-15'
+      - targets: ['147.46.78.205:9100']
+        labels:
+          machine_id: '311-2-16'
+      - targets: ['147.46.78.206:9100']
+        labels:
+          machine_id: '311-2-17'
+      - targets: ['147.46.78.207:9100']
+        labels:
+          machine_id: '311-2-18'
+      - targets: ['147.46.78.208:9100']
+        labels:
+          machine_id: '311-2-19'
+      - targets: ['147.46.78.209:9100']
+        labels:
+          machine_id: '311-2-20'
+      - targets: ['147.46.78.210:9100']
+        labels:
+          machine_id: '311-2-21'
+      - targets: ['147.46.78.211:9100']
+        labels:
+          machine_id: '311-2-22'
+      - targets: ['147.46.78.212:9100']
+        labels:
+          machine_id: '311-2-23'
+      - targets: ['147.46.78.213:9100']
+        labels:
+          machine_id: '311-2-24'
+      - targets: ['147.46.78.214:9100']
+        labels:
+          machine_id: '311-2-25'
+      - targets: ['147.46.78.215:9100']
+        labels:
+          machine_id: '311-2-26'
+      - targets: ['147.46.78.216:9100']
+        labels:
+          machine_id: '311-2-27'
+      - targets: ['147.46.78.217:9100']
+        labels:
+          machine_id: '311-2-28'
+      - targets: ['147.46.78.218:9100']
+        labels:
+          machine_id: '311-2-29'
+      - targets: ['147.46.78.219:9100']
+        labels:
+          machine_id: '311-2-30'
+    - job_name: 'lounge'
+      metrics_path: /metrics
+      static_configs:
+      - targets: ['147.46.127.102:9100']
+        labels:
+          machine_id: '314-A01'
+      - targets: ['147.46.127.103:9100']
+        labels:
+          machine_id: '314-A02'
+      - targets: ['147.46.127.104:9100']
+        labels:
+          machine_id: '314-A03'
+      - targets: ['147.46.127.105:9100']
+        labels:
+          machine_id: '314-A04'
+      - targets: ['147.46.127.106:9100']
+        labels:
+          machine_id: '314-A05'
+      - targets: ['147.46.127.107:9100']
+        labels:
+          machine_id: '314-A06'
+      - targets: ['147.46.127.108:9100']
+        labels:
+          machine_id: '314-A07'
+      - targets: ['147.46.127.109:9100']
+        labels:
+          machine_id: '314-A08'
+      - targets: ['147.46.127.110:9100']
+        labels:
+          machine_id: '314-B01'
+      - targets: ['147.46.127.111:9100']
+        labels:
+          machine_id: '314-B02'
+      - targets: ['147.46.127.112:9100']
+        labels:
+          machine_id: '314-B03'
+      - targets: ['147.46.127.113:9100']
+        labels:
+          machine_id: '314-B04'
+      - targets: ['147.46.127.114:9100']
+        labels:
+          machine_id: '314-B05'
+      - targets: ['147.46.127.115:9100']
+        labels:
+          machine_id: '314-B06'
+      - targets: ['147.46.127.116:9100']
+        labels:
+          machine_id: '314-B07'
+      - targets: ['147.46.127.117:9100']
+        labels:
+          machine_id: '314-B08'
+      - targets: ['147.46.127.118:9100']
+        labels:
+          machine_id: '314-C01'
+      - targets: ['147.46.127.119:9100']
+        labels:
+          machine_id: '314-C02'
+      - targets: ['147.46.127.120:9100']
+        labels:
+          machine_id: '314-C03'
+      - targets: ['147.46.127.121:9100']
+        labels:
+          machine_id: '314-C04'
+      - targets: ['147.46.127.122:9100']
+        labels:
+          machine_id: '314-C05'
+      - targets: ['147.46.127.123:9100']
+        labels:
+          machine_id: '314-C06'
+      - targets: ['147.46.127.124:9100']
+        labels:
+          machine_id: '314-C07'
+      - targets: ['147.46.127.125:9100']
+        labels:
+          machine_id: '314-C08'
+      - targets: ['147.46.127.126:9100']
+        labels:
+          machine_id: '314-C09'
+      - targets: ['147.46.127.127:9100']
+        labels:
+          machine_id: '314-C10'
+      - targets: ['147.46.127.128:9100']
+        labels:
+          machine_id: '314-C11'
+      - targets: ['147.46.127.129:9100']
+        labels:
+          machine_id: '314-C12'
+      - targets: ['147.46.127.130:9100']
+        labels:
+          machine_id: '314-C13'
+      - targets: ['147.46.127.131:9100']
+        labels:
+          machine_id: '314-C14'
+    - job_name: 'servers'
+      metrics_path: /metrics
+      static_configs:
+      - targets: ['martini.snucse.org:9100']
+        labels:
+          machine_id: 'martini'
+      - targets: ['skyy.snucse.org:9100']
+        labels:
+          machine_id: 'skyy'
+      - targets: ['sherry.snucse.org:9100']
+        labels:
+          machine_id: 'sherry'


### PR DESCRIPTION
[`.prometheus.prometheusSpec.additionalScrapeConfigs`](https://github.com/prometheus-community/helm-charts/blob/4da088ca394f4ae1bcce30f69a67aad5964e5800/charts/kube-prometheus-stack/values.yaml#L2674-L2726) 를 쓰는 경우 이렇게 할 수 있을 듯 합니다.
서비스 모니터를 쓰는 경우에는 서비스 + 엔드포인트를 따로 정의해서 구성할 수 있을 거 같은데, 이건 여러 개 한번에 넣으려면 어떻게 해야할 지 잘 모르겠어요.

몰래 `helm upgrade` 해서 확인해보고 `helm rollback` 으로 돌렸어요 😃

![image](https://user-images.githubusercontent.com/6398492/201536774-f25687e6-3d76-41da-9f20-17f6c3a22936.png)