### PR TITLE
인스턴스 유형 `t3.large`로 변경

### DIFF
--- a/practice.tf
+++ b/practice.tf
@@ -13,7 +13,7 @@ module "vpc_practice" {
 
 resource "aws_instance" "bacchus_practice" {
   ami           = data.aws_ami.debian_bullseye.id
-  instance_type = "t3.micro"
+  instance_type = "t3.large"
 
   vpc_security_group_ids = [
     aws_security_group.bacchus_practice.id,


### PR DESCRIPTION
실습용 인스턴스 유형을 `t3.large`로 올립니다.
인스턴스 ID는 `i-0f876636ec9cd742d` 입니다. (import용도)