### PR TITLE
Revert "feat: add dex oidc provider & readonly role (#98)"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,6 @@ terraform {
       version = "~> 4.32"
     }
 
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 4.0"
-    }
-
     cloudflare = {
       source  = "cloudflare/cloudflare"
       version = "~> 4.1"

--- a/oidc.tf
+++ b/oidc.tf
@@ -1,34 +1,3 @@
-data "tls_certificate" "dex_cert" {
-  url = "https://auth.bacchus.io/dex"
-}
-resource "aws_iam_openid_connect_provider" "dex_provider" {
-  client_id_list  = ["bacchus-aws"]
-  thumbprint_list = [data.tls_certificate.dex_cert.certificates[0].sha1_fingerprint]
-  url             = "https://auth.bacchus.io/dex"
-}
-
-data "aws_iam_policy_document" "dex_readonly_oidc" {
-  statement {
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    principals {
-      type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.dex_provider.arn]
-    }
-    condition {
-      test     = "ForAnyValue:StringEquals"
-      variable = "auth.bacchus.io/dex:groups"
-      values   = ["regular-members@bacchus.snucse.org"]
-    }
-  }
-}
-resource "aws_iam_role" "dex_readonly" {
-  name        = "dex-readonly"
-  description = "Role to be assumed with OIDC token"
-
-  assume_role_policy  = data.aws_iam_policy_document.dex_readonly_oidc.json
-  managed_policy_arns = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
-}
-
 resource "aws_iam_openid_connect_provider" "github_oidc_provider" {
   url = "https://token.actions.githubusercontent.com"
 


### PR DESCRIPTION
AWS에서 아무 claim이나 사용하도록 혀용하지 않아서 email, groups는 사용 못하고 `"sub": "ChUxMTE1MDcxOTc5OTI5OTQ5NjAwMDYSBmdvb2dsZQ"` 같은걸로 지정해야하는데 그것보다는 aws user 주는게 나을 것 같아요